### PR TITLE
reset makeprg after :Norminette

### DIFF
--- a/plugin/norminette.vim
+++ b/plugin/norminette.vim
@@ -13,10 +13,12 @@
 command! Norminette :call NorminetteCompiler()
 
 function! NorminetteCompiler()
+	let l:makeprg_save = &makeprg
 	compiler norminette
 	silent make % | redraw! | cc
 	copen
 	compiler gcc
+	let &makeprg = l:makeprg_save
 endfunction
 
 " Close quickfix window when closing file


### PR DESCRIPTION
As a heavy user of `:make` for compiling, I had trouble with `:Norminette` since it overrides the makeprg variable after it is called.
Here is a simple fix: it saves the previous makeprg value at the beginning and restores it at the end.